### PR TITLE
Ajout du déploiement automatique sur Github Pages

### DIFF
--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -1,6 +1,8 @@
 name: Autodeploy to Github Pages
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -9,20 +9,17 @@ jobs:
     steps:
     - name: Checkout 🛎️
       uses: actions/checkout@v2
-
     - name: Setup Node.js
       uses: actions/setup-node@v2
       with:
         node-version: '16'
         cache: 'npm'
-
-      - name: Install and Build 🔧
-        run: |
-          (cd repl && npm link && bash build.sh)
-          npm ci
-          npm run link-all
-          npm run build --if-present
-
+    - name: Install and Build 🔧
+      run: |
+        (cd repl && npm link && bash build.sh)
+        npm ci
+        npm run link-all
+        npm run build --if-present
     - name: Deploy 🚀
       if: ${{ github.event_name == 'push' }}
       uses: JamesIves/github-pages-deploy-action@4.1.5

--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Checkout 🛎️
       uses: actions/checkout@v2
 
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Setup Node.js
       uses: actions/setup-node@v2
       with:
         node-version: '16'

--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -1,0 +1,31 @@
+name: Autodeploy to Github Pages
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout 🛎️
+      uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+        cache: 'npm'
+
+      - name: Install and Build 🔧
+        run: |
+          (cd repl && npm link && bash build.sh)
+          npm ci
+          npm run link-all
+          npm run build --if-present
+
+    - name: Deploy 🚀
+      if: ${{ github.event_name == 'push' }}
+      uses: JamesIves/github-pages-deploy-action@4.1.5
+      with:
+        branch: gh-pages
+        folder: dist

--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -17,6 +17,7 @@ jobs:
     - name: Install and Build 🔧
       run: |
         (cd repl && npm link && bash build.sh)
+        (cd honkit-plugin-french-typography && npm link)
         npm ci
         npm run link-all
         npm run build --if-present

--- a/.github/workflows/autodeploy.yml
+++ b/.github/workflows/autodeploy.yml
@@ -26,4 +26,4 @@ jobs:
       uses: JamesIves/github-pages-deploy-action@4.1.5
       with:
         branch: gh-pages
-        folder: dist
+        folder: _book

--- a/README.md
+++ b/README.md
@@ -12,12 +12,17 @@ La traduction est encore en cours, les contributions sont les bienvenues !
     sudo npm link
     bash build.sh
 
+### Installer le plugin pour les typos FR
+
+    cd honkit-plugin-french-typography
+    npm link
+
 ### Installer Honkit
 
 Placez-vous à la racine du projet, puis :
 
     npm install
-    npm link gitbook-plugin-elm-repl
+    npm run link-all
 
 ## Générer le livre
 


### PR DESCRIPTION
Déploiement automatique sur Github pages lors d'un push sur master.

Build des plugins honkit, du projet en lui-même puis déploiement sur gh-pages.

Script inspiré de https://github.com/MTES-MCT/wikicarbone/blob/46f7afbc1c1e15a2e555ccee0216b8a27eea6f9b/.github/workflows/node.js.yml et https://github.com/marketplace/actions/deploy-to-github-pages

